### PR TITLE
change callback handle state

### DIFF
--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -67,6 +67,9 @@ controller_interface::CallbackReturn DiffDriveController::on_init()
     return controller_interface::CallbackReturn::ERROR;
   }
 
+  callback_handle_ = get_node()->add_on_set_parameters_callback(
+    std::bind(&DiffDriveController::on_param_change, this, std::placeholders::_1));
+  
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -111,9 +114,6 @@ controller_interface::return_type DiffDriveController::update(
     }
     return controller_interface::return_type::OK;
   }
-
-  callback_handle_ = get_node()->add_on_set_parameters_callback(
-    std::bind(&DiffDriveController::on_param_change, this, std::placeholders::_1));
 
   if (use_deceleration_){
     limiter_linear_.min_acceleration_ = deceleration_;


### PR DESCRIPTION

![Screenshot from 2023-11-24 09-50-17](https://github.com/saha-robotics/ros2_controllers/assets/72468520/1352bdc9-2f43-4e6b-a6d8-6711e321c28a)

When run the 'up' command, sometimes collision monitor stuck in 'service not avaible, waiting again...'. Controllers not initilizing the parameter server and causing the this problem.
[Clickup task](https://app.clickup.com/t/86bwhmjxr)