### PR TITLE
feat:set to parameter dynamic

### DIFF
--- a/diff_drive_controller/include/diff_drive_controller/speed_limiter.hpp
+++ b/diff_drive_controller/include/diff_drive_controller/speed_limiter.hpp
@@ -88,15 +88,17 @@ public:
   // Velocity limits:
   double min_velocity_;
   double max_velocity_;
-private:
+  
+    // Jerk limits:
+  double min_jerk_;
+  double max_jerk_;
+  
   // Enable/Disable velocity/acceleration/jerk limits:
   bool has_velocity_limits_;
   bool has_acceleration_limits_;
   bool has_jerk_limits_;
 
-  // Jerk limits:
-  double min_jerk_;
-  double max_jerk_;
+
 };
 
 }  // namespace diff_drive_controller

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -543,119 +543,121 @@ rcl_interfaces::msg::SetParametersResult DiffDriveController::on_param_change(co
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
 
-  for (const auto & parameter : parameters)
-  {
-    if (parameter.get_name() == "linear.x.deceleration")
-    {
-      deceleration_ = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.deceleration' changed to: %f", deceleration_);
-    }
-    else if (parameter.get_name() == "use_deceleration")
-    {
-      use_deceleration_ = parameter.as_bool();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'use_deceleration' changed to: %s", use_deceleration_ ? "true" : "false");
-    }
-    else if (parameter.get_name() == "max_linear_x_vel")
-    {
-      max_linear_x_vel_ = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'max_linear_x_vel' changed to: %f", max_linear_x_vel_);
-    }
-    else if (parameter.get_name() == "linear.x.max_velocity")
-    {
-      params_.linear.x.max_velocity = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_velocity' changed to: %f", params_.linear.x.max_velocity);
-    }
-    else if (parameter.get_name() == "linear.x.min_velocity")
-    {
-      params_.linear.x.min_velocity = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_velocity' changed to: %f", params_.linear.x.min_velocity);
-    }
-    else if (parameter.get_name() == "linear.x.min_acceleration")
-    {
-      params_.linear.x.min_acceleration = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_acceleration' changed to: %f", params_.linear.x.min_acceleration);
-    }
-    else if (parameter.get_name() == "linear.x.min_jerk")
-    {
-      params_.linear.x.min_jerk = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_jerk' changed to: %f", params_.linear.x.min_jerk);
-    }
-    else if (parameter.get_name() == "linear.x.max_acceleration")
-    {
-      params_.linear.x.max_acceleration = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_acceleration' changed to: %f", params_.linear.x.max_acceleration);
-    }
-    else if (parameter.get_name() == "linear.x.max_jerk")
-    {
-      params_.linear.x.max_jerk = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_jerk' changed to: %f", params_.linear.x.max_jerk);
-    }
-    else if (parameter.get_name() == "linear.x.has_velocity_limits")
-    {
-      params_.linear.x.has_velocity_limits = parameter.as_bool();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_velocity_limits' changed to: %s", params_.linear.x.has_velocity_limits ? "true" : "false");
-    }
-    else if (parameter.get_name() == "linear.x.has_acceleration_limits")
-    {
-      params_.linear.x.has_acceleration_limits = parameter.as_bool();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_acceleration_limits' changed to: %s", params_.linear.x.has_acceleration_limits ? "true" : "false");
-    }
-    else if (parameter.get_name() == "linear.x.has_jerk_limits")
-    {
-      params_.linear.x.has_jerk_limits = parameter.as_bool();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_jerk_limits' changed to: %s", params_.linear.x.has_jerk_limits ? "true" : "false");
-    }
-    else if (parameter.get_name() == "angular.z.max_velocity")
-    {
-      params_.angular.z.max_velocity = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_velocity' changed to: %f", params_.angular.z.max_velocity);
-    }
-    else if (parameter.get_name() == "angular.z.min_velocity")
-    {
-      params_.angular.z.min_velocity = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_velocity' changed to: %f", params_.angular.z.min_velocity);
-    }
-    else if (parameter.get_name() == "angular.z.min_acceleration")
-    {
-      params_.angular.z.min_acceleration = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_acceleration' changed to: %f", params_.angular.z.min_acceleration);
-    }
-    else if (parameter.get_name() == "angular.z.min_jerk")
-    {
-      params_.angular.z.min_jerk = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_jerk' changed to: %f", params_.angular.z.min_jerk);
-    }
-    else if (parameter.get_name() == "angular.z.max_acceleration")
-    {
-      params_.angular.z.max_acceleration = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_acceleration' changed to: %f", params_.angular.z.max_acceleration);
-    }
-    else if (parameter.get_name() == "angular.z.max_jerk")
-    {
-      params_.angular.z.max_jerk = parameter.as_double();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_jerk' changed to: %f", params_.angular.z.max_jerk);
-    }
-    else if (parameter.get_name() == "angular.z.has_velocity_limits")
-    {
-      params_.angular.z.has_velocity_limits = parameter.as_bool();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_velocity_limits' changed to: %s", params_.angular.z.has_velocity_limits ? "true" : "false");
-    }
-    else if (parameter.get_name() == "angular.z.has_acceleration_limits")
-    {
-      params_.angular.z.has_acceleration_limits = parameter.as_bool();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_acceleration_limits' changed to: %s", params_.angular.z.has_acceleration_limits ? "true" : "false");
-    }
-    else if (parameter.get_name() == "angular.z.has_jerk_limits")
-    {
-      params_.angular.z.has_jerk_limits = parameter.as_bool();
-      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_jerk_limits' changed to: %s", params_.angular.z.has_jerk_limits ? "true" : "false");
-    }
-    else
-    {
-      result.successful = false;
-      return result;
-    }
-  }
+  params_ = param_listener_->get_params();
+  // for (const auto & parameter : parameters)
+  // {
+    
+    // if (parameter.get_name() == "linear.x.deceleration")
+    // {
+    //   deceleration_ = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.deceleration' changed to: %f", deceleration_);
+    // }
+    // else if (parameter.get_name() == "use_deceleration")
+    // {
+    //   use_deceleration_ = parameter.as_bool();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'use_deceleration' changed to: %s", use_deceleration_ ? "true" : "false");
+    // }
+    // else if (parameter.get_name() == "max_linear_x_vel")
+    // {
+    //   max_linear_x_vel_ = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'max_linear_x_vel' changed to: %f", max_linear_x_vel_);
+    // }
+    // else if (parameter.get_name() == "linear.x.max_velocity")
+    // {
+    //   params_.linear.x.max_velocity = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_velocity' changed to: %f", params_.linear.x.max_velocity);
+    // }
+    // else if (parameter.get_name() == "linear.x.min_velocity")
+    // {
+    //   params_.linear.x.min_velocity = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_velocity' changed to: %f", params_.linear.x.min_velocity);
+    // }
+    // else if (parameter.get_name() == "linear.x.min_acceleration")
+    // {
+    //   params_.linear.x.min_acceleration = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_acceleration' changed to: %f", params_.linear.x.min_acceleration);
+    // }
+    // else if (parameter.get_name() == "linear.x.min_jerk")
+    // {
+    //   params_.linear.x.min_jerk = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_jerk' changed to: %f", params_.linear.x.min_jerk);
+    // }
+    // else if (parameter.get_name() == "linear.x.max_acceleration")
+    // {
+    //   params_.linear.x.max_acceleration = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_acceleration' changed to: %f", params_.linear.x.max_acceleration);
+    // }
+    // else if (parameter.get_name() == "linear.x.max_jerk")
+    // {
+    //   params_.linear.x.max_jerk = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_jerk' changed to: %f", params_.linear.x.max_jerk);
+    // }
+    // else if (parameter.get_name() == "linear.x.has_velocity_limits")
+    // {
+    //   params_.linear.x.has_velocity_limits = parameter.as_bool();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_velocity_limits' changed to: %s", params_.linear.x.has_velocity_limits ? "true" : "false");
+    // }
+    // else if (parameter.get_name() == "linear.x.has_acceleration_limits")
+    // {
+    //   params_.linear.x.has_acceleration_limits = parameter.as_bool();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_acceleration_limits' changed to: %s", params_.linear.x.has_acceleration_limits ? "true" : "false");
+    // }
+    // else if (parameter.get_name() == "linear.x.has_jerk_limits")
+    // {
+    //   params_.linear.x.has_jerk_limits = parameter.as_bool();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_jerk_limits' changed to: %s", params_.linear.x.has_jerk_limits ? "true" : "false");
+    // }
+    // else if (parameter.get_name() == "angular.z.max_velocity")
+    // {
+    //   params_.angular.z.max_velocity = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_velocity' changed to: %f", params_.angular.z.max_velocity);
+    // }
+    // else if (parameter.get_name() == "angular.z.min_velocity")
+    // {
+    //   params_.angular.z.min_velocity = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_velocity' changed to: %f", params_.angular.z.min_velocity);
+    // }
+    // else if (parameter.get_name() == "angular.z.min_acceleration")
+    // {
+    //   params_.angular.z.min_acceleration = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_acceleration' changed to: %f", params_.angular.z.min_acceleration);
+    // }
+    // else if (parameter.get_name() == "angular.z.min_jerk")
+    // {
+    //   params_.angular.z.min_jerk = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_jerk' changed to: %f", params_.angular.z.min_jerk);
+    // }
+    // else if (parameter.get_name() == "angular.z.max_acceleration")
+    // {
+    //   params_.angular.z.max_acceleration = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_acceleration' changed to: %f", params_.angular.z.max_acceleration);
+    // }
+    // else if (parameter.get_name() == "angular.z.max_jerk")
+    // {
+    //   params_.angular.z.max_jerk = parameter.as_double();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_jerk' changed to: %f", params_.angular.z.max_jerk);
+    // }
+    // else if (parameter.get_name() == "angular.z.has_velocity_limits")
+    // {
+    //   params_.angular.z.has_velocity_limits = parameter.as_bool();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_velocity_limits' changed to: %s", params_.angular.z.has_velocity_limits ? "true" : "false");
+    // }
+    // else if (parameter.get_name() == "angular.z.has_acceleration_limits")
+    // {
+    //   params_.angular.z.has_acceleration_limits = parameter.as_bool();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_acceleration_limits' changed to: %s", params_.angular.z.has_acceleration_limits ? "true" : "false");
+    // }
+    // else if (parameter.get_name() == "angular.z.has_jerk_limits")
+    // {
+    //   params_.angular.z.has_jerk_limits = parameter.as_bool();
+    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_jerk_limits' changed to: %s", params_.angular.z.has_jerk_limits ? "true" : "false");
+    // }
+    // else
+    // {
+    //   result.successful = false;
+    //   return result;
+    // }
+  // }
 
   limiter_linear_ = SpeedLimiter(
     params_.linear.x.has_velocity_limits, params_.linear.x.has_acceleration_limits,

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -574,8 +574,183 @@ rcl_interfaces::msg::SetParametersResult DiffDriveController::on_param_change(co
       // RCLCPP_WARN(get_node()->get_logger(), "max_linear_x_vel changed to: %f", parameter.as_double());
       max_linear_x_vel_ = parameter.as_double();
     }
-    result.successful = true;
+    if (parameter.get_name() == "wheel_separation")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "wheel_separation changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "wheels_per_side")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "wheels_per_side changed to: %d", parameter.as_int());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "wheel_radius")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "wheel_radius changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "wheel_separation_multiplier")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "wheel_separation_multiplier changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "left_wheel_radius_multiplier")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "left_wheel_radius_multiplier changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "right_wheel_radius_multiplier")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "right_wheel_radius_multiplier changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "publish_rate")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "publish_rate changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "odom_frame_id")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "odom_frame_id changed to: %s", parameter.as_string().c_str());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "base_frame_id")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "base_frame_id changed to: %s", parameter.as_string().c_str());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "pose_covariance_diagonal")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "pose_covariance_diagonal changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "twist_covariance_diagonal")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "twist_covariance_diagonal changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "open_loop")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "open_loop changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "position_feedback")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "position_feedback changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "enable_odom_tf")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "enable_odom_tf changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "cmd_vel_timeout")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "cmd_vel_timeout changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "publish_limited_velocity")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "publish_limited_velocity changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "use_stamped_vel")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "use_stamped_vel changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.has_velocity_limits")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.has_velocity_limits changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.has_acceleration_limits")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.has_acceleration_limits changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.has_jerk_limits")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.has_jerk_limits changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.max_velocity")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.max_velocity changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.min_velocity")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.min_velocity changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.max_acceleration")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.max_acceleration changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.min_acceleration")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.min_acceleration changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.max_jerk")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.max_jerk changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "linear.x.min_jerk")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "linear.x.min_jerk changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.has_velocity_limits")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.has_velocity_limits changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.has_acceleration_limits")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.has_acceleration_limits changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.has_jerk_limits")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.has_jerk_limits changed to: %d", parameter.as_bool());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.max_velocity")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.max_velocity changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.min_velocity")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.min_velocity changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.max_acceleration")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.max_acceleration changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.min_acceleration")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.min_acceleration changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.max_jerk")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.max_jerk changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
+    if (parameter.get_name() == "angular.z.min_jerk")
+    {
+      RCLCPP_WARN(get_node()->get_logger(), "angular.z.min_jerk changed to: %f", parameter.as_double());
+      result.successful = true;
+    }
   }
+  
   return result;
 }
 

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -115,18 +115,30 @@ controller_interface::return_type DiffDriveController::update(
     return controller_interface::return_type::OK;
   }
 
-  limiter_linear_.max_velocity_ = params_.linear.x.max_velocity;
+  // limiter_linear_.max_velocity_ = params_.linear.x.max_velocity;
 
-  if (use_deceleration_){
-    limiter_linear_.min_acceleration_ = deceleration_;
-  }
-  else{
-    limiter_linear_.min_acceleration_ = params_.linear.x.min_acceleration;
-  }
+  // if (use_deceleration_){
+  //   limiter_linear_.min_acceleration_ = deceleration_;
+  // }
+  // else{
+  //   limiter_linear_.min_acceleration_ = params_.linear.x.min_acceleration;
+  // }
   
-  if (max_linear_x_vel_ > 0){
-    limiter_linear_.max_velocity_ = max_linear_x_vel_;
-  }
+  // if (max_linear_x_vel_ > 0){
+  //   limiter_linear_.max_velocity_ = max_linear_x_vel_;
+  // }
+
+  // param_listener_->get_params();
+  // if (param_listener_->is_old(params_))
+  // {
+  //   // params_ = param_listener_->get_params();
+  //   RCLCPP_WARN(logger, "Parameters were updated");
+  //   limiter_linear_ = SpeedLimiter(
+  //     params_.linear.x.has_velocity_limits, params_.linear.x.has_acceleration_limits,
+  //     params_.linear.x.has_jerk_limits, params_.linear.x.min_velocity, params_.linear.x.max_velocity,
+  //     params_.linear.x.min_acceleration, params_.linear.x.max_acceleration, params_.linear.x.min_jerk,
+  //     params_.linear.x.max_jerk);
+  // }
 
   std::shared_ptr<Twist> last_command_msg;
   received_velocity_msg_ptr_.get(last_command_msg);
@@ -529,30 +541,135 @@ controller_interface::CallbackReturn DiffDriveController::on_error(const rclcpp_
 rcl_interfaces::msg::SetParametersResult DiffDriveController::on_param_change(const std::vector<rclcpp::Parameter> & parameters)
 {
   rcl_interfaces::msg::SetParametersResult result;
-  result.successful = false;
+  result.successful = true;
+
   for (const auto & parameter : parameters)
   {
-    if (parameter.get_name() == "linear.x.deceleration"){
+    if (parameter.get_name() == "linear.x.deceleration")
+    {
       deceleration_ = parameter.as_double();
-      result.successful = true;
-      // RCLCPP_WARN(get_node()->get_logger(), "deceleration changed to: %f", parameter.as_double());
-      // if (!use_deceleration_){
-      //   RCLCPP_WARN(get_node()->get_logger(), "Deceleration is not used, set use_deceleration to true to use it");
-      // }
-
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.deceleration' changed to: %f", deceleration_);
     }
-    if (parameter.get_name() == "use_deceleration"){
-      // RCLCPP_WARN(get_node()->get_logger(), "use_deceleration changed to: %d", parameter.as_bool());
+    else if (parameter.get_name() == "use_deceleration")
+    {
       use_deceleration_ = parameter.as_bool();
-      result.successful = true;
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'use_deceleration' changed to: %s", use_deceleration_ ? "true" : "false");
     }
-    if (parameter.get_name() == "max_linear_x_vel"){
-      // RCLCPP_WARN(get_node()->get_logger(), "max_linear_x_vel changed to: %f", parameter.as_double());
+    else if (parameter.get_name() == "max_linear_x_vel")
+    {
       max_linear_x_vel_ = parameter.as_double();
-      result.successful = true;
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'max_linear_x_vel' changed to: %f", max_linear_x_vel_);
     }
-    return result;
+    else if (parameter.get_name() == "linear.x.max_velocity")
+    {
+      params_.linear.x.max_velocity = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_velocity' changed to: %f", params_.linear.x.max_velocity);
+    }
+    else if (parameter.get_name() == "linear.x.min_velocity")
+    {
+      params_.linear.x.min_velocity = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_velocity' changed to: %f", params_.linear.x.min_velocity);
+    }
+    else if (parameter.get_name() == "linear.x.min_acceleration")
+    {
+      params_.linear.x.min_acceleration = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_acceleration' changed to: %f", params_.linear.x.min_acceleration);
+    }
+    else if (parameter.get_name() == "linear.x.min_jerk")
+    {
+      params_.linear.x.min_jerk = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_jerk' changed to: %f", params_.linear.x.min_jerk);
+    }
+    else if (parameter.get_name() == "linear.x.max_acceleration")
+    {
+      params_.linear.x.max_acceleration = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_acceleration' changed to: %f", params_.linear.x.max_acceleration);
+    }
+    else if (parameter.get_name() == "linear.x.max_jerk")
+    {
+      params_.linear.x.max_jerk = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_jerk' changed to: %f", params_.linear.x.max_jerk);
+    }
+    else if (parameter.get_name() == "linear.x.has_velocity_limits")
+    {
+      params_.linear.x.has_velocity_limits = parameter.as_bool();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_velocity_limits' changed to: %s", params_.linear.x.has_velocity_limits ? "true" : "false");
+    }
+    else if (parameter.get_name() == "linear.x.has_acceleration_limits")
+    {
+      params_.linear.x.has_acceleration_limits = parameter.as_bool();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_acceleration_limits' changed to: %s", params_.linear.x.has_acceleration_limits ? "true" : "false");
+    }
+    else if (parameter.get_name() == "linear.x.has_jerk_limits")
+    {
+      params_.linear.x.has_jerk_limits = parameter.as_bool();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_jerk_limits' changed to: %s", params_.linear.x.has_jerk_limits ? "true" : "false");
+    }
+    else if (parameter.get_name() == "angular.z.max_velocity")
+    {
+      params_.angular.z.max_velocity = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_velocity' changed to: %f", params_.angular.z.max_velocity);
+    }
+    else if (parameter.get_name() == "angular.z.min_velocity")
+    {
+      params_.angular.z.min_velocity = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_velocity' changed to: %f", params_.angular.z.min_velocity);
+    }
+    else if (parameter.get_name() == "angular.z.min_acceleration")
+    {
+      params_.angular.z.min_acceleration = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_acceleration' changed to: %f", params_.angular.z.min_acceleration);
+    }
+    else if (parameter.get_name() == "angular.z.min_jerk")
+    {
+      params_.angular.z.min_jerk = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_jerk' changed to: %f", params_.angular.z.min_jerk);
+    }
+    else if (parameter.get_name() == "angular.z.max_acceleration")
+    {
+      params_.angular.z.max_acceleration = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_acceleration' changed to: %f", params_.angular.z.max_acceleration);
+    }
+    else if (parameter.get_name() == "angular.z.max_jerk")
+    {
+      params_.angular.z.max_jerk = parameter.as_double();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_jerk' changed to: %f", params_.angular.z.max_jerk);
+    }
+    else if (parameter.get_name() == "angular.z.has_velocity_limits")
+    {
+      params_.angular.z.has_velocity_limits = parameter.as_bool();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_velocity_limits' changed to: %s", params_.angular.z.has_velocity_limits ? "true" : "false");
+    }
+    else if (parameter.get_name() == "angular.z.has_acceleration_limits")
+    {
+      params_.angular.z.has_acceleration_limits = parameter.as_bool();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_acceleration_limits' changed to: %s", params_.angular.z.has_acceleration_limits ? "true" : "false");
+    }
+    else if (parameter.get_name() == "angular.z.has_jerk_limits")
+    {
+      params_.angular.z.has_jerk_limits = parameter.as_bool();
+      RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_jerk_limits' changed to: %s", params_.angular.z.has_jerk_limits ? "true" : "false");
+    }
+    else
+    {
+      result.successful = false;
+      return result;
+    }
   }
+
+  limiter_linear_ = SpeedLimiter(
+    params_.linear.x.has_velocity_limits, params_.linear.x.has_acceleration_limits,
+    params_.linear.x.has_jerk_limits, params_.linear.x.min_velocity, params_.linear.x.max_velocity,
+    params_.linear.x.min_acceleration, params_.linear.x.max_acceleration, params_.linear.x.min_jerk,
+    params_.linear.x.max_jerk);
+
+  limiter_angular_ = SpeedLimiter(
+    params_.angular.z.has_velocity_limits, params_.angular.z.has_acceleration_limits,
+    params_.angular.z.has_jerk_limits, params_.angular.z.min_velocity, params_.angular.z.max_velocity,
+    params_.angular.z.min_acceleration, params_.angular.z.max_acceleration, params_.angular.z.min_jerk,
+    params_.angular.z.max_jerk);
+
+  return result;
 }
 
 bool DiffDriveController::reset()

--- a/diff_drive_controller/src/diff_drive_controller.cpp
+++ b/diff_drive_controller/src/diff_drive_controller.cpp
@@ -115,6 +115,7 @@ controller_interface::return_type DiffDriveController::update(
     return controller_interface::return_type::OK;
   }
 
+  //! Removed use_deceleration, deceleration_, max_linear_x_vel_ as they are not used
   // limiter_linear_.max_velocity_ = params_.linear.x.max_velocity;
 
   // if (use_deceleration_){
@@ -128,17 +129,30 @@ controller_interface::return_type DiffDriveController::update(
   //   limiter_linear_.max_velocity_ = max_linear_x_vel_;
   // }
 
-  // param_listener_->get_params();
-  // if (param_listener_->is_old(params_))
-  // {
-  //   // params_ = param_listener_->get_params();
-  //   RCLCPP_WARN(logger, "Parameters were updated");
-  //   limiter_linear_ = SpeedLimiter(
-  //     params_.linear.x.has_velocity_limits, params_.linear.x.has_acceleration_limits,
-  //     params_.linear.x.has_jerk_limits, params_.linear.x.min_velocity, params_.linear.x.max_velocity,
-  //     params_.linear.x.min_acceleration, params_.linear.x.max_acceleration, params_.linear.x.min_jerk,
-  //     params_.linear.x.max_jerk);
-  // }
+  if (param_listener_->is_old(params_))
+  {
+    params_ = param_listener_->get_params();
+    RCLCPP_WARN(logger, "Parameters were updated");
+
+    const double wheel_separation = params_.wheel_separation_multiplier * params_.wheel_separation;
+    const double left_wheel_radius = params_.left_wheel_radius_multiplier * params_.wheel_radius;
+    const double right_wheel_radius = params_.right_wheel_radius_multiplier * params_.wheel_radius;
+
+    odometry_.setWheelParams(wheel_separation, left_wheel_radius, right_wheel_radius);
+    odometry_.setVelocityRollingWindowSize(params_.velocity_rolling_window_size);
+    
+    limiter_linear_ = SpeedLimiter(
+      params_.linear.x.has_velocity_limits, params_.linear.x.has_acceleration_limits,
+      params_.linear.x.has_jerk_limits, params_.linear.x.min_velocity, params_.linear.x.max_velocity,
+      params_.linear.x.min_acceleration, params_.linear.x.max_acceleration, params_.linear.x.min_jerk,
+      params_.linear.x.max_jerk);
+
+    limiter_angular_ = SpeedLimiter(
+      params_.angular.z.has_velocity_limits, params_.angular.z.has_acceleration_limits,
+      params_.angular.z.has_jerk_limits, params_.angular.z.min_velocity, params_.angular.z.max_velocity,
+      params_.angular.z.min_acceleration, params_.angular.z.max_acceleration, params_.angular.z.min_jerk,
+      params_.angular.z.max_jerk);
+  }
 
   std::shared_ptr<Twist> last_command_msg;
   received_velocity_msg_ptr_.get(last_command_msg);
@@ -541,136 +555,27 @@ controller_interface::CallbackReturn DiffDriveController::on_error(const rclcpp_
 rcl_interfaces::msg::SetParametersResult DiffDriveController::on_param_change(const std::vector<rclcpp::Parameter> & parameters)
 {
   rcl_interfaces::msg::SetParametersResult result;
-  result.successful = true;
+  result.successful = false;
+  for (const auto & parameter : parameters)
+  {
+    if (parameter.get_name() == "linear.x.deceleration"){
+      deceleration_ = parameter.as_double();
+      // RCLCPP_WARN(get_node()->get_logger(), "deceleration changed to: %f", parameter.as_double());
+      // if (!use_deceleration_){
+      //   RCLCPP_WARN(get_node()->get_logger(), "Deceleration is not used, set use_deceleration to true to use it");
+      // }
 
-  params_ = param_listener_->get_params();
-  // for (const auto & parameter : parameters)
-  // {
-    
-    // if (parameter.get_name() == "linear.x.deceleration")
-    // {
-    //   deceleration_ = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.deceleration' changed to: %f", deceleration_);
-    // }
-    // else if (parameter.get_name() == "use_deceleration")
-    // {
-    //   use_deceleration_ = parameter.as_bool();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'use_deceleration' changed to: %s", use_deceleration_ ? "true" : "false");
-    // }
-    // else if (parameter.get_name() == "max_linear_x_vel")
-    // {
-    //   max_linear_x_vel_ = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'max_linear_x_vel' changed to: %f", max_linear_x_vel_);
-    // }
-    // else if (parameter.get_name() == "linear.x.max_velocity")
-    // {
-    //   params_.linear.x.max_velocity = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_velocity' changed to: %f", params_.linear.x.max_velocity);
-    // }
-    // else if (parameter.get_name() == "linear.x.min_velocity")
-    // {
-    //   params_.linear.x.min_velocity = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_velocity' changed to: %f", params_.linear.x.min_velocity);
-    // }
-    // else if (parameter.get_name() == "linear.x.min_acceleration")
-    // {
-    //   params_.linear.x.min_acceleration = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_acceleration' changed to: %f", params_.linear.x.min_acceleration);
-    // }
-    // else if (parameter.get_name() == "linear.x.min_jerk")
-    // {
-    //   params_.linear.x.min_jerk = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.min_jerk' changed to: %f", params_.linear.x.min_jerk);
-    // }
-    // else if (parameter.get_name() == "linear.x.max_acceleration")
-    // {
-    //   params_.linear.x.max_acceleration = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_acceleration' changed to: %f", params_.linear.x.max_acceleration);
-    // }
-    // else if (parameter.get_name() == "linear.x.max_jerk")
-    // {
-    //   params_.linear.x.max_jerk = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.max_jerk' changed to: %f", params_.linear.x.max_jerk);
-    // }
-    // else if (parameter.get_name() == "linear.x.has_velocity_limits")
-    // {
-    //   params_.linear.x.has_velocity_limits = parameter.as_bool();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_velocity_limits' changed to: %s", params_.linear.x.has_velocity_limits ? "true" : "false");
-    // }
-    // else if (parameter.get_name() == "linear.x.has_acceleration_limits")
-    // {
-    //   params_.linear.x.has_acceleration_limits = parameter.as_bool();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_acceleration_limits' changed to: %s", params_.linear.x.has_acceleration_limits ? "true" : "false");
-    // }
-    // else if (parameter.get_name() == "linear.x.has_jerk_limits")
-    // {
-    //   params_.linear.x.has_jerk_limits = parameter.as_bool();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'linear.x.has_jerk_limits' changed to: %s", params_.linear.x.has_jerk_limits ? "true" : "false");
-    // }
-    // else if (parameter.get_name() == "angular.z.max_velocity")
-    // {
-    //   params_.angular.z.max_velocity = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_velocity' changed to: %f", params_.angular.z.max_velocity);
-    // }
-    // else if (parameter.get_name() == "angular.z.min_velocity")
-    // {
-    //   params_.angular.z.min_velocity = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_velocity' changed to: %f", params_.angular.z.min_velocity);
-    // }
-    // else if (parameter.get_name() == "angular.z.min_acceleration")
-    // {
-    //   params_.angular.z.min_acceleration = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_acceleration' changed to: %f", params_.angular.z.min_acceleration);
-    // }
-    // else if (parameter.get_name() == "angular.z.min_jerk")
-    // {
-    //   params_.angular.z.min_jerk = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.min_jerk' changed to: %f", params_.angular.z.min_jerk);
-    // }
-    // else if (parameter.get_name() == "angular.z.max_acceleration")
-    // {
-    //   params_.angular.z.max_acceleration = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_acceleration' changed to: %f", params_.angular.z.max_acceleration);
-    // }
-    // else if (parameter.get_name() == "angular.z.max_jerk")
-    // {
-    //   params_.angular.z.max_jerk = parameter.as_double();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.max_jerk' changed to: %f", params_.angular.z.max_jerk);
-    // }
-    // else if (parameter.get_name() == "angular.z.has_velocity_limits")
-    // {
-    //   params_.angular.z.has_velocity_limits = parameter.as_bool();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_velocity_limits' changed to: %s", params_.angular.z.has_velocity_limits ? "true" : "false");
-    // }
-    // else if (parameter.get_name() == "angular.z.has_acceleration_limits")
-    // {
-    //   params_.angular.z.has_acceleration_limits = parameter.as_bool();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_acceleration_limits' changed to: %s", params_.angular.z.has_acceleration_limits ? "true" : "false");
-    // }
-    // else if (parameter.get_name() == "angular.z.has_jerk_limits")
-    // {
-    //   params_.angular.z.has_jerk_limits = parameter.as_bool();
-    //   RCLCPP_INFO(get_node()->get_logger(), "Parameter 'angular.z.has_jerk_limits' changed to: %s", params_.angular.z.has_jerk_limits ? "true" : "false");
-    // }
-    // else
-    // {
-    //   result.successful = false;
-    //   return result;
-    // }
-  // }
-
-  limiter_linear_ = SpeedLimiter(
-    params_.linear.x.has_velocity_limits, params_.linear.x.has_acceleration_limits,
-    params_.linear.x.has_jerk_limits, params_.linear.x.min_velocity, params_.linear.x.max_velocity,
-    params_.linear.x.min_acceleration, params_.linear.x.max_acceleration, params_.linear.x.min_jerk,
-    params_.linear.x.max_jerk);
-
-  limiter_angular_ = SpeedLimiter(
-    params_.angular.z.has_velocity_limits, params_.angular.z.has_acceleration_limits,
-    params_.angular.z.has_jerk_limits, params_.angular.z.min_velocity, params_.angular.z.max_velocity,
-    params_.angular.z.min_acceleration, params_.angular.z.max_acceleration, params_.angular.z.min_jerk,
-    params_.angular.z.max_jerk);
-
+    }
+    if (parameter.get_name() == "use_deceleration"){
+      // RCLCPP_WARN(get_node()->get_logger(), "use_deceleration changed to: %d", parameter.as_bool());
+      use_deceleration_ = parameter.as_bool();
+    }
+    if (parameter.get_name() == "max_linear_x_vel"){
+      // RCLCPP_WARN(get_node()->get_logger(), "max_linear_x_vel changed to: %f", parameter.as_double());
+      max_linear_x_vel_ = parameter.as_double();
+    }
+    result.successful = true;
+  }
   return result;
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `diff_drive_controller` to improve parameter handling and simplify the codebase. The most important changes include moving jerk limits in the `SpeedLimiter` class, removing unused parameters, and updating parameter handling in the `DiffDriveController`.

Parameter handling improvements:

* [`diff_drive_controller/include/diff_drive_controller/speed_limiter.hpp`](diffhunk://#diff-a1abf1a86610dbaac664114a9b5bb93ca9334ae753e0db0abead837af05d30e0L91-R101): Moved the jerk limits (`min_jerk_` and `max_jerk_`) to be grouped with the velocity limits.
* [`diff_drive_controller/src/diff_drive_controller.cpp`](diffhunk://#diff-f8d3a930a6782d85b295ef6bce89dc2a757ae540cc80128e8044aee6ddee5df9L118-R154): Removed the use of `use_deceleration`, `deceleration_`, and `max_linear_x_vel_` as these parameters were not used.

Code simplification:

* [`diff_drive_controller/src/diff_drive_controller.cpp`](diffhunk://#diff-f8d3a930a6782d85b295ef6bce89dc2a757ae540cc80128e8044aee6ddee5df9L537): Updated the `on_param_change` method to remove the setting of `result.successful` for unused parameters. [[1]](diffhunk://#diff-f8d3a930a6782d85b295ef6bce89dc2a757ae540cc80128e8044aee6ddee5df9L537) [[2]](diffhunk://#diff-f8d3a930a6782d85b295ef6bce89dc2a757ae540cc80128e8044aee6ddee5df9L547-L556)